### PR TITLE
Create empty-elements.js

### DIFF
--- a/empty-elements.js
+++ b/empty-elements.js
@@ -1,0 +1,1 @@
+javascript:(function(){var a=document.createElement('style'),b;document.head.appendChild(a);b=a.sheet;b.insertRule('*:not([src]):not([type]):empty{border:2px dotted #00f !important;background-color:#00f;}',0);})()


### PR DESCRIPTION
Find elements that are empty — no content, no whitespace. It will not highlight images (by excluding elements with a src attribute) nor form inputs (by excluding elements with a type element).
